### PR TITLE
correct failing link to "dummyurl", meant to point to blog post

### DIFF
--- a/redis-cluster-application-example/README.md
+++ b/redis-cluster-application-example/README.md
@@ -1,6 +1,6 @@
 # README
 
-This repository contains sample code and scripts that accompany our [**Migrating from a Redis Cluster to a DragonflyDB on a single node**](https://dummyurl) tutorial.
+This repository contains sample code and scripts that accompany our [**Migrating from a Redis Cluster to a DragonflyDB on a single node**](https://www.dragonflydb.io/blog/migrating-from-a-redis-cluster-to-a-dragonfly-on-a-single-node) tutorial.
 
 In this tutorial, you learn how to migrate data from a Redis Cluster to a single-node DragonflyDB instance. You can use the sample application `/app` to demonstrate the migration process and cover everything step by step.
 


### PR DESCRIPTION
I happened upon this while perusing the project, and clearly the dummyurl was meant to be replaced at some point. I found a blog post with the name that was shown as the TEXT of the link, so am proposing that as the correction, assuming you agree it's correct.